### PR TITLE
chore(docs): move build status next to repo's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # guarda-nota
+[![Build Status](https://travis-ci.org/thaisfreitas/guarda-nota.svg?branch=master)](https://travis-ci.org/thaisfreitas/guarda-nota)
 
 The proposal of this project is to use the minimum to build an API with node js using express to manage personal invoices. 
 
@@ -9,10 +10,3 @@ $ npm install # install dependencies
 $ npm start   # run locally
 $ npm test    # run the tests
 ```
-
-## TRAVIS CI 
-[![Build Status](https://travis-ci.org/thaisfreitas/guarda-nota.svg?branch=master)](https://travis-ci.org/thaisfreitas/guarda-nota)
-
-To know the build status and continuous integrations just take a look at our CI:
-https://travis-ci.org/thaisfreitas/guarda-nota
-


### PR DESCRIPTION
In my opinion is self-explanatory just having the clickable button with the build status, if tomorrow you change the CI from travis-ci to circle CI – for instance – you just change the URL. Let me know what you think :)